### PR TITLE
Update repository links for new organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jupyterlab-blockly-ipylgbst
 
-[![Github Actions Status](https://github.com/QuantStack/jupyterlab-blockly-ipylgbst/workflows/Build/badge.svg)](https://github.com/QuantStack/jupyterlab-blockly-ipylgbst/actions/workflows/build.yml)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantStack/jupyterlab-blockly-ipylgbst/main?urlpath=lab/tree/examples/demo.jpblockly)
+[![Github Actions Status](https://github.com/jupyter-robotics/jupyterlab-blockly-ipylgbst/workflows/Build/badge.svg)](https://github.com/jupyter-robotics/jupyterlab-blockly-ipylgbst/actions/workflows/build.yml)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyter-robotics/jupyterlab-blockly-ipylgbst/main?urlpath=lab/tree/examples/demo.jpblockly)
 Blockly extension for JupyterLab to control the Lego Boost, using the ipylgbst library.
 
 ## Blockly

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "Lego Boost",
     "robot"
   ],
-  "homepage": "https://github.com/QuantStack/jupyterlab-blockly-ipylgbst",
+  "homepage": "https://github.com/jupyter-robotics/jupyterlab-blockly-ipylgbst",
   "bugs": {
-    "url": "https://github.com/QuantStack/jupyterlab-blockly-ipylgbst/issues"
+    "url": "https://github.com/jupyter-robotics/jupyterlab-blockly-ipylgbst/issues"
   },
   "license": "BSD-3-Clause",
   "author": {
@@ -28,7 +28,7 @@
   "style": "style/index.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/QuantStack/jupyterlab-blockly-ipylgbst.git"
+    "url": "https://github.com/jupyter-robotics/jupyterlab-blockly-ipylgbst.git"
   },
   "scripts": {
     "build": "jlpm build:lib && jlpm build:labextension:dev",


### PR DESCRIPTION
Update links in repository, since it has been moved from `QuantStack` to `jupyter-robotics`.